### PR TITLE
raycast (para poder usar o clique do mouse) e labels mais legíveis

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "vue": "^3.5.18",
     "vue-router": "^4.5.1",
-    "three": "^0.179.1"
+    "three": "^0.179.1",
+    "troika-three-text": "^0.52.4"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -217,7 +217,6 @@ async function loadModels(buildings: Building[]) {
             text.outlineWidth = 0.15;
             text.outlineColor = 0x000000;
             text.visible = false
-            text.getBoundingClientRect
             text.sync(() => {
                 // Labels!!
                 const box = new THREE.Box3().setFromObject(model)

--- a/src/services/mapService.ts
+++ b/src/services/mapService.ts
@@ -15,6 +15,8 @@ let renderer: THREE.WebGLRenderer | null = null
 let scene: THREE.Scene | null = null
 let camera: THREE.PerspectiveCamera | null = null
 let controls: OrbitControls | null = null
+let mousePointer: THREE.Vector2
+let raycaster: THREE.Raycaster
 let animationRunning = false
 
 const loadedModels = new Map<string, THREE.Object3D>()
@@ -25,6 +27,9 @@ async function initIfNeeded(containerSize?: { w: number, h: number }) {
     initialized = true
 
     scene = new THREE.Scene()
+    raycaster = new THREE.Raycaster()
+    raycaster.params.Line.threshold = 3
+    mousePointer = new THREE.Vector2()
 
     camera = new THREE.PerspectiveCamera(10, (containerSize?.w ?? 1) / (containerSize?.h ?? 1), 0.01, 2000)
     camera.position.set(-68, 200, 322.84)
@@ -81,6 +86,19 @@ function mount(container: HTMLElement) {
         camera!.aspect = r.width / r.height
         camera!.updateProjectionMatrix()
         renderer!.setSize(r.width, r.height)
+    })
+    window.addEventListener('click', (event: any) => {
+        if (!renderer) return
+        const rect = renderer.domElement.getBoundingClientRect();
+        mousePointer.x = ( ( event.clientX - rect.left ) / ( rect.right - rect.left ) ) * 2 - 1;
+        mousePointer.y = - ( ( event.clientY - rect.top ) / ( rect.bottom - rect.top) ) * 2 + 1;
+        raycaster.setFromCamera(mousePointer, camera!)
+        loadedModels.forEach((value, key, map) => {
+            const intersect = raycaster.intersectObject(value, true)
+            if (intersect.length > 0) {
+                console.log("intersecção!!")
+            }
+        })
     })
 }
 

--- a/src/troika-three-text.d.ts
+++ b/src/troika-three-text.d.ts
@@ -1,0 +1,26 @@
+// So para remover uns erros irritantes, porem irrelevantes, que aparecem no editor
+declare module 'troika-three-text' {
+    import { Object3D, BufferGeometry, Box3 } from 'three'
+
+    export class Text extends Object3D {
+        // text content
+        text: string
+        // style
+        fontSize: number
+        color: number | string
+        outlineWidth?: number
+        outlineColor?: number | string
+        // visibility
+        visible: boolean
+        // geometry access (very small surface of the real API)
+        geometry: BufferGeometry & { boundingBox: Box3 }
+
+        // sync callback invoked when text layout is ready
+        sync(cb?: () => void): void
+
+        // constructor
+        constructor()
+    }
+
+    export default Text
+}


### PR DESCRIPTION
Melhoria na legibilidade das legendas que indicam os nomes dos prédios. Uma biblioteca nova foi adicionada (troika-three-text)

Também é possível, agora, clicar nos prédios para mostrar seus nomes, os quais permanecem invisíveis por padrão para evitar poluição visual.